### PR TITLE
Change module referencing for calling JWT decode

### DIFF
--- a/lib/DMAO/WardenJWT/strategy.rb
+++ b/lib/DMAO/WardenJWT/strategy.rb
@@ -65,7 +65,7 @@ module DMAO
         jwt_audience = ENV['JWT_AUDIENCE']
 
         begin
-          decoded_token = JWT.decode jwt, jwt_secret, true, { :verify_iat => verify_iat, :iss => jwt_issuer, :verify_iss => verify_iss, :aud => jwt_audience, :verify_aud => verify_aud, :algorithm => 'HS256'}
+          decoded_token = ::JWT.decode jwt, jwt_secret, true, { :verify_iat => verify_iat, :iss => jwt_issuer, :verify_iss => verify_iss, :aud => jwt_audience, :verify_aud => verify_aud, :algorithm => 'HS256'}
         rescue ::JWT::ExpiredSignature
           logger.info('JWT - Expired Signature')
           return nil


### PR DESCRIPTION
When running in services and there are errors with the token instead of catching and logging name errors for unknown constant are raised.

This fixes the referencing to the JWT modules errors. This is caused by the JWT Service API wrapper being in the module namespace of `DMAO::JWT` and when included in the same project as warden JWT in the namespace of `DMAO::WardenJWT` module namespace errors occur due to how module names are looked up and this clash between `JWT` and `DMAO::JWT`